### PR TITLE
Show percentage value if base value (ie. from previous time range) is not available.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.8 (2024-01-23)
+
+* Show percentage value if base value (ie. from previous time range) is not available.
+
 ## 1.0.7 (2022-11-06)
 
 * Fixed prefix in case of negative percentage trend

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-percent-trend-panel",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Grafana percent trend panel",
   "scripts": {
     "build": "grafana-toolkit plugin:build",

--- a/src/PercentPanel.tsx
+++ b/src/PercentPanel.tsx
@@ -107,22 +107,22 @@ export const PercentPanel: React.FC<Props> = ({ options, data, width, height }) 
     serie.fields.find((field) => field.name === options.baseValueField)
   );
 
-  if (!percentageValueSerie || !baseValueSerie) {
+  if (!percentageValueSerie) {
     return <p>Selected series are not available</p>;
   }
 
   const percentageValueField = percentageValueSerie.fields.find((field) => field.name === options.percentageValueField);
-  const baseValueField = baseValueSerie.fields.find((field) => field.name === options.baseValueField);
+  const baseValueField = baseValueSerie?.fields.find((field) => field.name === options.baseValueField);
 
-  if (!percentageValueField || !baseValueField) {
+  if (!percentageValueField) {
     return <p>Selected fields are not available</p>;
   }
-  if (percentageValueField.values.length === 0 || baseValueField.values.length === 0) {
+  if (percentageValueField.values.length === 0) {
     return <p>Selected fields are empty</p>;
   }
 
   const percentageValueSum = percentageValueField.values.toArray().reduce((sum, current) => sum + current, 0);
-  const baseValueSum = baseValueField.values.toArray().reduce((sum, current) => sum + current, 0);
+  const baseValueSum = baseValueField ? baseValueField.values.toArray().reduce((sum, current) => sum + current, 0) : 0;
 
   const display = prepareTrendDisplay(options, theme.visualization, baseValueSum, percentageValueSum);
 


### PR DESCRIPTION
If the the base value is not available, but the percentage value is, currently a hint "Selected series are not avaiblabe" is shown.
With this change the "percentage value" absolute value is shown instead (and a "N/A" hint for the percentage trend).

Example:

![image](https://github.com/nikos/grafana-percent-trend-panel/assets/89360266/a0b51e29-4cec-48ee-a52e-b25604c3ca48)
